### PR TITLE
dependencies から dotenv を削除

### DIFF
--- a/moneyforward_driver/config.py
+++ b/moneyforward_driver/config.py
@@ -1,7 +1,10 @@
 import os
-from dotenv import load_dotenv
 
-load_dotenv()  # Load environment variables from .env file
+try:
+    from dotenv import load_dotenv
+    load_dotenv()  # Load environment variables from .env file
+except ImportError:
+    pass
 
 MF_EMAIL = os.getenv('MF_EMAIL')
 MF_PASSWORD = os.getenv('MF_PASSWORD')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "moneyforward_driver"
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
-    "dotenv",
+    "python-dotenv",
     "html5lib",
     "logzero",
     "lxml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,8 @@ name = "moneyforward_driver"
 version = "0.1.1"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 dependencies = [
-    "python-dotenv",
     "html5lib",
     "logzero",
     "lxml",


### PR DESCRIPTION
dotenvのインストールにPython3.8以降が必要なため。